### PR TITLE
Replace hardcoded port name strings with typed constants

### DIFF
--- a/Hypnode.Core/Ports.cs
+++ b/Hypnode.Core/Ports.cs
@@ -1,0 +1,7 @@
+namespace Hypnode.Core;
+
+public static class Ports
+{
+    public const string Input = "IN";
+    public const string Output = "OUT";
+}

--- a/Hypnode.Logic/Compound/FullAdder.cs
+++ b/Hypnode.Logic/Compound/FullAdder.cs
@@ -8,89 +8,81 @@ namespace Hypnode.Logic.Compound;
 
 public class FullAdder(INodeGraph nodeGraph) : CompoundNode(nodeGraph)
 {
+    public const string InputA = "INA";
+    public const string InputB = "INB";
+    public const string InputC = "INC";
+    public const string OutputSum = "OUTSUM";
+    public const string OutputCarry = "OUTC";
+
     private Connection<LogicValue>? _aPort = null;
     private Connection<LogicValue>? _bPort = null;
     private Connection<LogicValue>? _carryIn = null;
-
     private Connection<LogicValue>? _sum = null;
     private Connection<LogicValue>? _carryOut = null;
 
     public override INode SetPort(string portName, IConnection connection)
     {
-        if (portName == "INA" && connection is Connection<LogicValue> con0) _aPort = con0;
-        if (portName == "INB" && connection is Connection<LogicValue> con1) _bPort = con1;
-        if (portName == "INC" && connection is Connection<LogicValue> con2) _carryIn = con2;
-        if (portName == "OUTSUM" && connection is Connection<LogicValue> con3) _sum = con3;
-        if (portName == "OUTC" && connection is Connection<LogicValue> con4) _carryOut = con4;
-
+        if (portName == InputA && connection is Connection<LogicValue> con0) _aPort = con0;
+        if (portName == InputB && connection is Connection<LogicValue> con1) _bPort = con1;
+        if (portName == InputC && connection is Connection<LogicValue> con2) _carryIn = con2;
+        if (portName == OutputSum && connection is Connection<LogicValue> con3) _sum = con3;
+        if (portName == OutputCarry && connection is Connection<LogicValue> con4) _carryOut = con4;
         return this;
     }
 
     public override IEnumerator Execute()
     {
-        if (_aPort is null)
-            throw new InvalidOperationException("Input port A is not set");
-
-        if (_bPort is null)
-            throw new InvalidOperationException("Input port B is not set");
-
-        if (_carryIn is null)
-            throw new InvalidOperationException("Input port _carryIn is not set");
+        if (_aPort is null) throw new InvalidOperationException("Input port A is not set");
+        if (_bPort is null) throw new InvalidOperationException("Input port B is not set");
+        if (_carryIn is null) throw new InvalidOperationException("Input port C is not set");
 
         while (true)
         {
-            if ((_aPort.IsClosed && !_aPort.HasData) ||
-                (_bPort.IsClosed && !_bPort.HasData) ||
-                (_carryIn.IsClosed && !_carryIn.HasData))
+            if ((_aPort.IsClosed && !_aPort.HasData) || (_bPort.IsClosed && !_bPort.HasData) || (_carryIn.IsClosed && !_carryIn.HasData))
                 break;
-
-            if (!_aPort.HasData || !_bPort.HasData || !_carryIn.HasData)
-            {
-                yield return null;
-                continue;
-            }
+            if (!_aPort.HasData || !_bPort.HasData || !_carryIn.HasData) { yield return null; continue; }
 
             var a = _aPort.Receive();
             var b = _bPort.Receive();
             var c = _carryIn.Receive();
 
             var graph = new CoroutineNodeGraph();
-            var AtoDemux1 = graph.CreateConnection<LogicValue>();
-            var Demux1toXor1 = graph.CreateConnection<LogicValue>();
-            var BtoDemux2 = graph.CreateConnection<LogicValue>();
-            var Demux2toXor1 = graph.CreateConnection<LogicValue>();
-            var CtoDemux3 = graph.CreateConnection<LogicValue>();
-            var Demux3toXor2 = graph.CreateConnection<LogicValue>();
-            var Xor1toDemux4 = graph.CreateConnection<LogicValue>();
-            var Demux4toXor2 = graph.CreateConnection<LogicValue>();
-            var Demux4toAnd1 = graph.CreateConnection<LogicValue>();
-            var Demux3toAnd1 = graph.CreateConnection<LogicValue>();
-            var Demux1toAnd2 = graph.CreateConnection<LogicValue>();
-            var Demux2toAnd2 = graph.CreateConnection<LogicValue>();
-            var And1toOr = graph.CreateConnection<LogicValue>();
-            var And2toOr = graph.CreateConnection<LogicValue>();
+            var aToDemux1 = graph.CreateConnection<LogicValue>();
+            var demux1ToXor1 = graph.CreateConnection<LogicValue>();
+            var bToDemux2 = graph.CreateConnection<LogicValue>();
+            var demux2ToXor1 = graph.CreateConnection<LogicValue>();
+            var cToDemux3 = graph.CreateConnection<LogicValue>();
+            var demux3ToXor2 = graph.CreateConnection<LogicValue>();
+            var xor1ToDemux4 = graph.CreateConnection<LogicValue>();
+            var demux4ToXor2 = graph.CreateConnection<LogicValue>();
+            var demux4ToAnd1 = graph.CreateConnection<LogicValue>();
+            var demux3ToAnd1 = graph.CreateConnection<LogicValue>();
+            var demux1ToAnd2 = graph.CreateConnection<LogicValue>();
+            var demux2ToAnd2 = graph.CreateConnection<LogicValue>();
+            var and1ToOr = graph.CreateConnection<LogicValue>();
+            var and2ToOr = graph.CreateConnection<LogicValue>();
             var toCarryOut = graph.CreateConnection<LogicValue>();
             var toSum = graph.CreateConnection<LogicValue>();
 
-            graph.AddNode(new PulseValue<LogicValue>(a)).SetPort("OUT", AtoDemux1);
-            graph.AddNode(new Splitter<LogicValue>()).SetPort("IN", AtoDemux1).SetPort("OUT", Demux1toXor1).SetPort("OUT", Demux1toAnd2);
-            graph.AddNode(new PulseValue<LogicValue>(b)).SetPort("OUT", BtoDemux2);
-            graph.AddNode(new Splitter<LogicValue>()).SetPort("IN", BtoDemux2).SetPort("OUT", Demux2toXor1).SetPort("OUT", Demux2toAnd2);
-            graph.AddNode(new PulseValue<LogicValue>(c)).SetPort("OUT", CtoDemux3);
-            graph.AddNode(new Splitter<LogicValue>()).SetPort("IN", CtoDemux3).SetPort("OUT", Demux3toXor2).SetPort("OUT", Demux3toAnd1);
-            graph.AddNode(new XorGate()).SetPort("INA", Demux1toXor1).SetPort("INB", Demux2toXor1).SetPort("OUT", Xor1toDemux4);
-            graph.AddNode(new XorGate()).SetPort("INA", Demux3toXor2).SetPort("INB", Demux4toXor2).SetPort("OUT", toSum);
+            graph.AddNode(new PulseValue<LogicValue>(a)).SetPort(PulseValue<LogicValue>.Output, aToDemux1);
+            graph.AddNode(new Splitter<LogicValue>()).SetPort(Splitter<LogicValue>.Input, aToDemux1).SetPort(Splitter<LogicValue>.Output, demux1ToXor1).SetPort(Splitter<LogicValue>.Output, demux1ToAnd2);
+            graph.AddNode(new PulseValue<LogicValue>(b)).SetPort(PulseValue<LogicValue>.Output, bToDemux2);
+            graph.AddNode(new Splitter<LogicValue>()).SetPort(Splitter<LogicValue>.Input, bToDemux2).SetPort(Splitter<LogicValue>.Output, demux2ToXor1).SetPort(Splitter<LogicValue>.Output, demux2ToAnd2);
+            graph.AddNode(new PulseValue<LogicValue>(c)).SetPort(PulseValue<LogicValue>.Output, cToDemux3);
+            graph.AddNode(new Splitter<LogicValue>()).SetPort(Splitter<LogicValue>.Input, cToDemux3).SetPort(Splitter<LogicValue>.Output, demux3ToXor2).SetPort(Splitter<LogicValue>.Output, demux3ToAnd1);
+            graph.AddNode(new XorGate()).SetPort(XorGate.InputA, demux1ToXor1).SetPort(XorGate.InputB, demux2ToXor1).SetPort(XorGate.Output, xor1ToDemux4);
+            graph.AddNode(new XorGate()).SetPort(XorGate.InputA, demux3ToXor2).SetPort(XorGate.InputB, demux4ToXor2).SetPort(XorGate.Output, toSum);
 
             var sumCell = new Register<LogicValue>();
-            graph.AddNode(sumCell).SetPort("IN", toSum);
+            graph.AddNode(sumCell).SetPort(Register<LogicValue>.Input, toSum);
 
-            graph.AddNode(new Splitter<LogicValue>()).SetPort("IN", Xor1toDemux4).SetPort("OUT", Demux4toXor2).SetPort("OUT", Demux4toAnd1);
-            graph.AddNode(new AndGate()).SetPort("INA", Demux4toAnd1).SetPort("INB", Demux3toAnd1).SetPort("OUT", And1toOr);
-            graph.AddNode(new AndGate()).SetPort("INA", Demux1toAnd2).SetPort("INB", Demux2toAnd2).SetPort("OUT", And2toOr);
-            graph.AddNode(new OrGate()).SetPort("INA", And2toOr).SetPort("INB", And1toOr).SetPort("OUT", toCarryOut);
+            graph.AddNode(new Splitter<LogicValue>()).SetPort(Splitter<LogicValue>.Input, xor1ToDemux4).SetPort(Splitter<LogicValue>.Output, demux4ToXor2).SetPort(Splitter<LogicValue>.Output, demux4ToAnd1);
+            graph.AddNode(new AndGate()).SetPort(AndGate.InputA, demux4ToAnd1).SetPort(AndGate.InputB, demux3ToAnd1).SetPort(AndGate.Output, and1ToOr);
+            graph.AddNode(new AndGate()).SetPort(AndGate.InputA, demux1ToAnd2).SetPort(AndGate.InputB, demux2ToAnd2).SetPort(AndGate.Output, and2ToOr);
+            graph.AddNode(new OrGate()).SetPort(OrGate.InputA, and2ToOr).SetPort(OrGate.InputB, and1ToOr).SetPort(OrGate.Output, toCarryOut);
 
             var carryCell = new Register<LogicValue>();
-            graph.AddNode(carryCell).SetPort("IN", toCarryOut);
+            graph.AddNode(carryCell).SetPort(Register<LogicValue>.Input, toCarryOut);
 
             yield return graph;
 

--- a/Hypnode.Logic/Compound/FullAdderByte.cs
+++ b/Hypnode.Logic/Compound/FullAdderByte.cs
@@ -8,38 +8,32 @@ namespace Hypnode.Logic.Compound;
 
 public class FullAdderByte(INodeGraph nodeGraph) : CompoundNode(nodeGraph)
 {
+    public const string InputA = "INA";
+    public const string InputB = "INB";
+    public const string OutputSum = "OUTSUM";
+
     private Connection<byte>? _aPort = null;
     private Connection<byte>? _bPort = null;
     private Connection<byte>? _sum = null;
 
     public override INode SetPort(string portName, IConnection connection)
     {
-        if (portName == "INA" && connection is Connection<byte> conn0) _aPort = conn0;
-        if (portName == "INB" && connection is Connection<byte> conn1) _bPort = conn1;
-        if (portName == "OUTSUM" && connection is Connection<byte> conn2) _sum = conn2;
-
+        if (portName == InputA && connection is Connection<byte> conn0) _aPort = conn0;
+        if (portName == InputB && connection is Connection<byte> conn1) _bPort = conn1;
+        if (portName == OutputSum && connection is Connection<byte> conn2) _sum = conn2;
         return this;
     }
 
     public override IEnumerator Execute()
     {
-        if (_aPort is null)
-            throw new InvalidOperationException("Input port A is not set");
-
-        if (_bPort is null)
-            throw new InvalidOperationException("Input port B is not set");
+        if (_aPort is null) throw new InvalidOperationException("Input port A is not set");
+        if (_bPort is null) throw new InvalidOperationException("Input port B is not set");
 
         while (true)
         {
-            if ((_aPort.IsClosed && !_aPort.HasData) ||
-                (_bPort.IsClosed && !_bPort.HasData))
+            if ((_aPort.IsClosed && !_aPort.HasData) || (_bPort.IsClosed && !_bPort.HasData))
                 break;
-
-            if (!_aPort.HasData || !_bPort.HasData)
-            {
-                yield return null;
-                continue;
-            }
+            if (!_aPort.HasData || !_bPort.HasData) { yield return null; continue; }
 
             var a = _aPort.Receive();
             var b = _bPort.Receive();
@@ -49,12 +43,12 @@ public class FullAdderByte(INodeGraph nodeGraph) : CompoundNode(nodeGraph)
             var bIn = graph.CreateConnection<byte>();
             var cIn = graph.CreateConnection<LogicValue>();
 
-            graph.AddNode(new PulseValue<byte>(a)).SetPort("OUT", aIn);
-            graph.AddNode(new PulseValue<byte>(b)).SetPort("OUT", bIn);
-            graph.AddNode(new PulseValue<LogicValue>(LogicValue.False)).SetPort("OUT", cIn);
+            graph.AddNode(new PulseValue<byte>(a)).SetPort(PulseValue<byte>.Output, aIn);
+            graph.AddNode(new PulseValue<byte>(b)).SetPort(PulseValue<byte>.Output, bIn);
+            graph.AddNode(new PulseValue<LogicValue>(LogicValue.False)).SetPort(PulseValue<LogicValue>.Output, cIn);
 
-            var aDemux = graph.AddNode(new ByteSplitterIn()).SetPort("IN", aIn);
-            var bDemux = graph.AddNode(new ByteSplitterIn()).SetPort("IN", bIn);
+            var aDemux = graph.AddNode(new ByteSplitterIn()).SetPort(ByteSplitterIn.Input, aIn);
+            var bDemux = graph.AddNode(new ByteSplitterIn()).SetPort(ByteSplitterIn.Input, bIn);
 
             Connection<LogicValue>? carry = null;
             var sumWires = new Connection<LogicValue>[8];
@@ -62,23 +56,22 @@ public class FullAdderByte(INodeGraph nodeGraph) : CompoundNode(nodeGraph)
             for (int i = 0; i < 8; ++i)
             {
                 var adder = graph.AddNode(new FullAdder(new CoroutineNodeGraph()));
-
                 var aWire = graph.CreateConnection<LogicValue>();
                 var bWire = graph.CreateConnection<LogicValue>();
 
                 aDemux.SetPort(i.ToString(), aWire);
                 bDemux.SetPort(i.ToString(), bWire);
 
-                adder.SetPort("INA", aWire);
-                adder.SetPort("INB", bWire);
-                adder.SetPort("INC", i == 0 ? cIn : carry!);
+                adder.SetPort(FullAdder.InputA, aWire);
+                adder.SetPort(FullAdder.InputB, bWire);
+                adder.SetPort(FullAdder.InputC, i == 0 ? cIn : carry!);
 
                 carry = graph.CreateConnection<LogicValue>();
                 var sumWire = graph.CreateConnection<LogicValue>();
                 sumWires[i] = sumWire;
 
-                adder.SetPort("OUTSUM", sumWire);
-                adder.SetPort("OUTC", carry);
+                adder.SetPort(FullAdder.OutputSum, sumWire);
+                adder.SetPort(FullAdder.OutputCarry, carry);
             }
 
             var sumMux = graph.AddNode(new ByteSplitterOut());
@@ -87,12 +80,12 @@ public class FullAdderByte(INodeGraph nodeGraph) : CompoundNode(nodeGraph)
             for (int i = 0; i < 8; ++i)
                 sumMux.SetPort(i.ToString(), sumWires[i]);
 
-            sumMux.SetPort("OUT", resultWire);
+            sumMux.SetPort(ByteSplitterOut.Output, resultWire);
 
             var result = new Register<byte>();
-            graph.AddNode(result).SetPort("IN", resultWire);
+            graph.AddNode(result).SetPort(Register<byte>.Input, resultWire);
 
-            graph.AddNode(new VoidSink<LogicValue>()).SetPort("_", carry!);
+            graph.AddNode(new VoidSink<LogicValue>()).SetPort(VoidSink<LogicValue>.Input, carry!);
 
             yield return graph;
 

--- a/Hypnode.Logic/Gates/AndGate.cs
+++ b/Hypnode.Logic/Gates/AndGate.cs
@@ -5,43 +5,36 @@ namespace Hypnode.Logic.Gates;
 
 public class AndGate : INode
 {
+    public const string InputA = "INA";
+    public const string InputB = "INB";
+    public const string Output = "OUT";
+
     private Connection<LogicValue>? _inputPortA = null;
     private Connection<LogicValue>? _inputPortB = null;
     private Connection<LogicValue>? _outputPort = null;
 
     public INode SetPort(string portName, IConnection connection)
     {
-        if (portName == "INA" && connection is Connection<LogicValue> con0) _inputPortA = con0;
-        if (portName == "INB" && connection is Connection<LogicValue> con1) _inputPortB = con1;
-        if (portName == "OUT" && connection is Connection<LogicValue> con2) _outputPort = con2;
-
+        if (portName == InputA && connection is Connection<LogicValue> con0) _inputPortA = con0;
+        if (portName == InputB && connection is Connection<LogicValue> con1) _inputPortB = con1;
+        if (portName == Output && connection is Connection<LogicValue> con2) _outputPort = con2;
         return this;
     }
 
     public IEnumerator Execute()
     {
-        if (_inputPortA is null)
-            throw new InvalidOperationException("Input port A is not set");
-
-        if (_inputPortB is null)
-            throw new InvalidOperationException("Input port B is not set");
+        if (_inputPortA is null) throw new InvalidOperationException("Input port A is not set");
+        if (_inputPortB is null) throw new InvalidOperationException("Input port B is not set");
 
         while (true)
         {
-            if ((_inputPortA.IsClosed && !_inputPortA.HasData) ||
-                (_inputPortB.IsClosed && !_inputPortB.HasData))
+            if ((_inputPortA.IsClosed && !_inputPortA.HasData) || (_inputPortB.IsClosed && !_inputPortB.HasData))
                 break;
-
-            if (!_inputPortA.HasData || !_inputPortB.HasData)
-            {
-                yield return null;
-                continue;
-            }
+            if (!_inputPortA.HasData || !_inputPortB.HasData) { yield return null; continue; }
 
             var a = _inputPortA.Receive();
             var b = _inputPortB.Receive();
-            var result = (a == LogicValue.True && b == LogicValue.True) ? LogicValue.True : LogicValue.False;
-            _outputPort?.Send(result);
+            _outputPort?.Send(a == LogicValue.True && b == LogicValue.True ? LogicValue.True : LogicValue.False);
         }
 
         _outputPort?.Close();

--- a/Hypnode.Logic/Gates/NotGate.cs
+++ b/Hypnode.Logic/Gates/NotGate.cs
@@ -5,32 +5,27 @@ namespace Hypnode.Logic.Gates;
 
 public class NotGate : INode
 {
+    public const string Input = "IN";
+    public const string Output = "OUT";
+
     private Connection<LogicValue>? _inputPort = null;
     private Connection<LogicValue>? _outputPort = null;
 
     public INode SetPort(string portName, IConnection connection)
     {
-        if (portName == "IN" && connection is Connection<LogicValue> con0) _inputPort = con0;
-        if (portName == "OUT" && connection is Connection<LogicValue> con1) _outputPort = con1;
-
+        if (portName == Input && connection is Connection<LogicValue> con0) _inputPort = con0;
+        if (portName == Output && connection is Connection<LogicValue> con1) _outputPort = con1;
         return this;
     }
 
     public IEnumerator Execute()
     {
-        if (_inputPort is null)
-            throw new InvalidOperationException("Input port is not set");
+        if (_inputPort is null) throw new InvalidOperationException("Input port is not set");
 
         while (true)
         {
-            if (_inputPort.IsClosed && !_inputPort.HasData)
-                break;
-
-            if (!_inputPort.HasData)
-            {
-                yield return null;
-                continue;
-            }
+            if (_inputPort.IsClosed && !_inputPort.HasData) break;
+            if (!_inputPort.HasData) { yield return null; continue; }
 
             var packet = _inputPort.Receive();
             _outputPort?.Send(packet == LogicValue.True ? LogicValue.False : LogicValue.True);

--- a/Hypnode.Logic/Gates/OrGate.cs
+++ b/Hypnode.Logic/Gates/OrGate.cs
@@ -5,43 +5,36 @@ namespace Hypnode.Logic.Gates;
 
 public class OrGate : INode
 {
+    public const string InputA = "INA";
+    public const string InputB = "INB";
+    public const string Output = "OUT";
+
     private Connection<LogicValue>? _inputPortA = null;
     private Connection<LogicValue>? _inputPortB = null;
     private Connection<LogicValue>? _outputPort = null;
 
     public INode SetPort(string portName, IConnection connection)
     {
-        if (portName == "INA" && connection is Connection<LogicValue> con0) _inputPortA = con0;
-        if (portName == "INB" && connection is Connection<LogicValue> con1) _inputPortB = con1;
-        if (portName == "OUT" && connection is Connection<LogicValue> con2) _outputPort = con2;
-
+        if (portName == InputA && connection is Connection<LogicValue> con0) _inputPortA = con0;
+        if (portName == InputB && connection is Connection<LogicValue> con1) _inputPortB = con1;
+        if (portName == Output && connection is Connection<LogicValue> con2) _outputPort = con2;
         return this;
     }
 
     public IEnumerator Execute()
     {
-        if (_inputPortA is null)
-            throw new InvalidOperationException("Input port A is not set");
-
-        if (_inputPortB is null)
-            throw new InvalidOperationException("Input port B is not set");
+        if (_inputPortA is null) throw new InvalidOperationException("Input port A is not set");
+        if (_inputPortB is null) throw new InvalidOperationException("Input port B is not set");
 
         while (true)
         {
-            if ((_inputPortA.IsClosed && !_inputPortA.HasData) ||
-                (_inputPortB.IsClosed && !_inputPortB.HasData))
+            if ((_inputPortA.IsClosed && !_inputPortA.HasData) || (_inputPortB.IsClosed && !_inputPortB.HasData))
                 break;
-
-            if (!_inputPortA.HasData || !_inputPortB.HasData)
-            {
-                yield return null;
-                continue;
-            }
+            if (!_inputPortA.HasData || !_inputPortB.HasData) { yield return null; continue; }
 
             var a = _inputPortA.Receive();
             var b = _inputPortB.Receive();
-            var result = (a == LogicValue.True || b == LogicValue.True) ? LogicValue.True : LogicValue.False;
-            _outputPort?.Send(result);
+            _outputPort?.Send(a == LogicValue.True || b == LogicValue.True ? LogicValue.True : LogicValue.False);
         }
 
         _outputPort?.Close();

--- a/Hypnode.Logic/Gates/XorGate.cs
+++ b/Hypnode.Logic/Gates/XorGate.cs
@@ -5,6 +5,10 @@ namespace Hypnode.Logic.Gates;
 
 public class XorGate : INode
 {
+    public const string InputA = "INA";
+    public const string InputB = "INB";
+    public const string Output = "OUT";
+
     private Connection<LogicValue>? _inputPortA = null;
     private Connection<LogicValue>? _inputPortB = null;
     private Connection<LogicValue>? _outputPort = null;
@@ -13,9 +17,9 @@ public class XorGate : INode
     {
         var result = portName switch
         {
-            "INA" => NodeExtensions.TryAttach(ref _inputPortA, connection),
-            "INB" => NodeExtensions.TryAttach(ref _inputPortB, connection),
-            "OUT" => NodeExtensions.TryAttach(ref _outputPort, connection),
+            InputA => NodeExtensions.TryAttach(ref _inputPortA, connection),
+            InputB => NodeExtensions.TryAttach(ref _inputPortB, connection),
+            Output => NodeExtensions.TryAttach(ref _outputPort, connection),
             _ => throw new InvalidOperationException($"Port {portName} is invalid"),
         };
 
@@ -27,23 +31,14 @@ public class XorGate : INode
 
     public IEnumerator Execute()
     {
-        if (_inputPortA is null)
-            throw new InvalidOperationException("Input port A is not set");
-
-        if (_inputPortB is null)
-            throw new InvalidOperationException("Input port B is not set");
+        if (_inputPortA is null) throw new InvalidOperationException("Input port A is not set");
+        if (_inputPortB is null) throw new InvalidOperationException("Input port B is not set");
 
         while (true)
         {
-            if ((_inputPortA.IsClosed && !_inputPortA.HasData) ||
-                (_inputPortB.IsClosed && !_inputPortB.HasData))
+            if ((_inputPortA.IsClosed && !_inputPortA.HasData) || (_inputPortB.IsClosed && !_inputPortB.HasData))
                 break;
-
-            if (!_inputPortA.HasData || !_inputPortB.HasData)
-            {
-                yield return null;
-                continue;
-            }
+            if (!_inputPortA.HasData || !_inputPortB.HasData) { yield return null; continue; }
 
             var a = _inputPortA.Receive();
             var b = _inputPortB.Receive();

--- a/Hypnode.Logic/Utils/ByteSplitterIn.cs
+++ b/Hypnode.Logic/Utils/ByteSplitterIn.cs
@@ -5,39 +5,31 @@ namespace Hypnode.Logic.Utils;
 
 public class ByteSplitterIn : INode
 {
+    public const string Input = "IN";
+
     private Connection<byte>? _inputPort = null;
     private readonly Connection<LogicValue>[] _outputPorts = new Connection<LogicValue>[8];
 
     public INode SetPort(string portName, IConnection connection)
     {
-        if (portName == "IN" && connection is Connection<byte> connIn) _inputPort = connIn;
-        if (portName == "0" && connection is Connection<LogicValue> conn0) _outputPorts[0] = conn0;
-        if (portName == "1" && connection is Connection<LogicValue> conn1) _outputPorts[1] = conn1;
-        if (portName == "2" && connection is Connection<LogicValue> conn2) _outputPorts[2] = conn2;
-        if (portName == "3" && connection is Connection<LogicValue> conn3) _outputPorts[3] = conn3;
-        if (portName == "4" && connection is Connection<LogicValue> conn4) _outputPorts[4] = conn4;
-        if (portName == "5" && connection is Connection<LogicValue> conn5) _outputPorts[5] = conn5;
-        if (portName == "6" && connection is Connection<LogicValue> conn6) _outputPorts[6] = conn6;
-        if (portName == "7" && connection is Connection<LogicValue> conn7) _outputPorts[7] = conn7;
+        if (portName == Input && connection is Connection<byte> connIn)
+            _inputPort = connIn;
+
+        if (int.TryParse(portName, out int idx) && idx >= 0 && idx < 8
+            && connection is Connection<LogicValue> connBit)
+            _outputPorts[idx] = connBit;
 
         return this;
     }
 
     public IEnumerator Execute()
     {
-        if (_inputPort is null)
-            throw new InvalidOperationException("Input port is not set");
+        if (_inputPort is null) throw new InvalidOperationException("Input port is not set");
 
         while (true)
         {
-            if (_inputPort.IsClosed && !_inputPort.HasData)
-                break;
-
-            if (!_inputPort.HasData)
-            {
-                yield return null;
-                continue;
-            }
+            if (_inputPort.IsClosed && !_inputPort.HasData) break;
+            if (!_inputPort.HasData) { yield return null; continue; }
 
             var packet = _inputPort.Receive();
             LogicValue[] values = [.. Enumerable.Range(0, 8)

--- a/Hypnode.Logic/Utils/ByteSplitterOut.cs
+++ b/Hypnode.Logic/Utils/ByteSplitterOut.cs
@@ -5,20 +5,19 @@ namespace Hypnode.Logic.Utils;
 
 public class ByteSplitterOut : INode
 {
+    public const string Output = "OUT";
+
     private readonly Connection<LogicValue>[] _inputPorts = new Connection<LogicValue>[8];
     private Connection<byte>? _outputPort = null;
 
     public INode SetPort(string portName, IConnection connection)
     {
-        if (portName == "0" && connection is Connection<LogicValue> conn0) _inputPorts[0] = conn0;
-        if (portName == "1" && connection is Connection<LogicValue> conn1) _inputPorts[1] = conn1;
-        if (portName == "2" && connection is Connection<LogicValue> conn2) _inputPorts[2] = conn2;
-        if (portName == "3" && connection is Connection<LogicValue> conn3) _inputPorts[3] = conn3;
-        if (portName == "4" && connection is Connection<LogicValue> conn4) _inputPorts[4] = conn4;
-        if (portName == "5" && connection is Connection<LogicValue> conn5) _inputPorts[5] = conn5;
-        if (portName == "6" && connection is Connection<LogicValue> conn6) _inputPorts[6] = conn6;
-        if (portName == "7" && connection is Connection<LogicValue> conn7) _inputPorts[7] = conn7;
-        if (portName == "OUT" && connection is Connection<byte> connOut) _outputPort = connOut;
+        if (portName == Output && connection is Connection<byte> connOut)
+            _outputPort = connOut;
+
+        if (int.TryParse(portName, out int idx) && idx >= 0 && idx < 8
+            && connection is Connection<LogicValue> connBit)
+            _inputPorts[idx] = connBit;
 
         return this;
     }
@@ -26,26 +25,16 @@ public class ByteSplitterOut : INode
     public IEnumerator Execute()
     {
         for (int i = 0; i < 8; i++)
-        {
             if (_inputPorts[i] is null)
                 throw new InvalidOperationException($"Input port {i} is not set");
-        }
 
         while (true)
         {
-            bool anyExhausted = Enumerable.Range(0, 8).Any(i =>
-                _inputPorts[i].IsClosed && !_inputPorts[i].HasData);
-
-            if (anyExhausted)
-                break;
+            bool anyExhausted = Enumerable.Range(0, 8).Any(i => _inputPorts[i].IsClosed && !_inputPorts[i].HasData);
+            if (anyExhausted) break;
 
             bool allReady = Enumerable.Range(0, 8).All(i => _inputPorts[i].HasData);
-
-            if (!allReady)
-            {
-                yield return null;
-                continue;
-            }
+            if (!allReady) { yield return null; continue; }
 
             var values = new LogicValue[8];
             for (int i = 0; i < 8; i++)

--- a/Hypnode.System/Common/Assert.cs
+++ b/Hypnode.System/Common/Assert.cs
@@ -5,32 +5,25 @@ namespace Hypnode.System.IO;
 
 public class Assert : INode
 {
+    public const string Input = "IN";
+
     private Connection<bool>? _inputPort = null;
 
     public INode SetPort(string portName, IConnection connection)
     {
-        if (portName == "IN" && connection is Connection<bool> con) _inputPort = con;
+        if (portName == Input && connection is Connection<bool> con) _inputPort = con;
         return this;
     }
 
     public IEnumerator Execute()
     {
-        if (_inputPort is null)
-            throw new InvalidOperationException("Input port is not set");
+        if (_inputPort is null) throw new InvalidOperationException("Input port is not set");
 
         while (true)
         {
-            if (_inputPort.IsClosed && !_inputPort.HasData)
-                break;
-
-            if (!_inputPort.HasData)
-            {
-                yield return null;
-                continue;
-            }
-
-            if (!_inputPort.Receive())
-                throw new InvalidOperationException("Assertion failed");
+            if (_inputPort.IsClosed && !_inputPort.HasData) break;
+            if (!_inputPort.HasData) { yield return null; continue; }
+            if (!_inputPort.Receive()) throw new InvalidOperationException("Assertion failed");
         }
     }
 }

--- a/Hypnode.System/Common/ConstValue.cs
+++ b/Hypnode.System/Common/ConstValue.cs
@@ -5,17 +5,16 @@ namespace Hypnode.System.Common;
 
 public class ConstValue<T> : INode
 {
+    public const string Output = "OUT";
+
     private T Value { get; set; }
     private Connection<T>? _outputPort = null;
 
-    public ConstValue(T value)
-    {
-        Value = value;
-    }
+    public ConstValue(T value) { Value = value; }
 
     public INode SetPort(string portName, IConnection connection)
     {
-        if (portName == "OUT" && connection is Connection<T> con) _outputPort = con;
+        if (portName == Output && connection is Connection<T> con) _outputPort = con;
         return this;
     }
 

--- a/Hypnode.System/Common/MultiPulseValue.cs
+++ b/Hypnode.System/Common/MultiPulseValue.cs
@@ -5,17 +5,16 @@ namespace Hypnode.System.Common;
 
 public class MultiPulseValue<T> : INode
 {
+    public const string Output = "OUT";
+
     private IEnumerable<T> Value { get; set; }
     private Connection<T>? _outputPort = null;
 
-    public MultiPulseValue(IEnumerable<T> value)
-    {
-        Value = value;
-    }
+    public MultiPulseValue(IEnumerable<T> value) { Value = value; }
 
     public INode SetPort(string portName, IConnection connection)
     {
-        if (portName == "OUT" && connection is Connection<T> con) _outputPort = con;
+        if (portName == Output && connection is Connection<T> con) _outputPort = con;
         return this;
     }
 

--- a/Hypnode.System/Common/PulseValue.cs
+++ b/Hypnode.System/Common/PulseValue.cs
@@ -5,17 +5,16 @@ namespace Hypnode.System.Common;
 
 public class PulseValue<T> : INode
 {
+    public const string Output = "OUT";
+
     private T Value { get; set; }
     private Connection<T>? _outputPort = null;
 
-    public PulseValue(T value)
-    {
-        Value = value;
-    }
+    public PulseValue(T value) { Value = value; }
 
     public INode SetPort(string portName, IConnection connection)
     {
-        if (portName == "OUT" && connection is Connection<T> con) _outputPort = con;
+        if (portName == Output && connection is Connection<T> con) _outputPort = con;
         return this;
     }
 

--- a/Hypnode.System/Common/Register.cs
+++ b/Hypnode.System/Common/Register.cs
@@ -5,12 +5,14 @@ namespace Hypnode.System.Common;
 
 public class Register<T> : INode
 {
+    public const string Input = "IN";
+
     private T? _value;
     private Connection<T>? _inputPort = null;
 
     public INode SetPort(string portName, IConnection connection)
     {
-        if (portName == "IN" && connection is Connection<T> con) _inputPort = con;
+        if (portName == Input && connection is Connection<T> con) _inputPort = con;
         return this;
     }
 
@@ -18,20 +20,12 @@ public class Register<T> : INode
 
     public IEnumerator Execute()
     {
-        if (_inputPort is null)
-            throw new InvalidOperationException("Input port is not set");
+        if (_inputPort is null) throw new InvalidOperationException("Input port is not set");
 
         while (true)
         {
-            if (_inputPort.IsClosed && !_inputPort.HasData)
-                break;
-
-            if (!_inputPort.HasData)
-            {
-                yield return null;
-                continue;
-            }
-
+            if (_inputPort.IsClosed && !_inputPort.HasData) break;
+            if (!_inputPort.HasData) { yield return null; continue; }
             _value = _inputPort.Receive();
         }
     }

--- a/Hypnode.System/Common/Splitter.cs
+++ b/Hypnode.System/Common/Splitter.cs
@@ -5,31 +5,27 @@ namespace Hypnode.System.Common;
 
 public class Splitter<T> : INode
 {
+    public const string Input = "IN";
+    public const string Output = "OUT";
+
     private Connection<T>? _inputPort = null;
     private readonly List<Connection<T>> _outputPorts = [];
 
     public INode SetPort(string portName, IConnection connection)
     {
-        if (portName == "IN" && connection is Connection<T> con0) _inputPort = con0;
-        if (portName == "OUT" && connection is Connection<T> con1) _outputPorts.Add(con1);
+        if (portName == Input && connection is Connection<T> con0) _inputPort = con0;
+        if (portName == Output && connection is Connection<T> con1) _outputPorts.Add(con1);
         return this;
     }
 
     public IEnumerator Execute()
     {
-        if (_inputPort is null)
-            throw new InvalidOperationException("Input port is not set");
+        if (_inputPort is null) throw new InvalidOperationException("Input port is not set");
 
         while (true)
         {
-            if (_inputPort.IsClosed && !_inputPort.HasData)
-                break;
-
-            if (!_inputPort.HasData)
-            {
-                yield return null;
-                continue;
-            }
+            if (_inputPort.IsClosed && !_inputPort.HasData) break;
+            if (!_inputPort.HasData) { yield return null; continue; }
 
             var packet = _inputPort.Receive();
             foreach (var conn in _outputPorts)

--- a/Hypnode.System/Common/VoidSink.cs
+++ b/Hypnode.System/Common/VoidSink.cs
@@ -5,6 +5,8 @@ namespace Hypnode.System.Common;
 
 public class VoidSink<T> : INode
 {
+    public const string Input = "_";
+
     private readonly List<Connection<T>> _inputPorts = [];
 
     public INode SetPort(string portName, IConnection connection)
@@ -20,10 +22,7 @@ public class VoidSink<T> : INode
         {
             anyReceived = false;
             foreach (var conn in _inputPorts)
-            {
-                while (conn.TryReceive(out _))
-                    anyReceived = true;
-            }
+                while (conn.TryReceive(out _)) anyReceived = true;
 
             if (anyReceived) yield return null;
         }

--- a/Hypnode.System/IO/Printer.cs
+++ b/Hypnode.System/IO/Printer.cs
@@ -5,30 +5,24 @@ namespace Hypnode.System.IO;
 
 public class Printer<T> : INode
 {
+    public const string Input = "IN";
+
     private Connection<T>? _inputPort = null;
 
     public INode SetPort(string portName, IConnection connection)
     {
-        if (portName == "IN" && connection is Connection<T> conn) _inputPort = conn;
+        if (portName == Input && connection is Connection<T> conn) _inputPort = conn;
         return this;
     }
 
     public IEnumerator Execute()
     {
-        if (_inputPort is null)
-            throw new InvalidOperationException("Input port is not set");
+        if (_inputPort is null) throw new InvalidOperationException("Input port is not set");
 
         while (true)
         {
-            if (_inputPort.IsClosed && !_inputPort.HasData)
-                break;
-
-            if (!_inputPort.HasData)
-            {
-                yield return null;
-                continue;
-            }
-
+            if (_inputPort.IsClosed && !_inputPort.HasData) break;
+            if (!_inputPort.HasData) { yield return null; continue; }
             Console.WriteLine($"{_inputPort.Receive()}");
         }
     }

--- a/Hypnode.System/Math/Generator.cs
+++ b/Hypnode.System/Math/Generator.cs
@@ -5,11 +5,13 @@ namespace Hypnode.System.Math;
 
 public class Generator : INode
 {
+    public const string Output = "OUT";
+
     private Connection<int>? _outputPort = null;
 
     public INode SetPort(string portName, IConnection connection)
     {
-        if (portName == "OUT" && connection is Connection<int> con) _outputPort = con;
+        if (portName == Output && connection is Connection<int> con) _outputPort = con;
         return this;
     }
 

--- a/Hypnode.System/Math/Squarer.cs
+++ b/Hypnode.System/Math/Squarer.cs
@@ -5,34 +5,28 @@ namespace Hypnode.System.Math;
 
 public class Squarer : INode
 {
+    public const string Input = "IN";
+    public const string Output = "OUT";
+
     private Connection<int>? _inputPort = null;
     private Connection<int>? _outputPort = null;
 
     public INode SetPort(string portName, IConnection connection)
     {
-        if (portName == "IN" && connection is Connection<int> con0) _inputPort = con0;
-        if (portName == "OUT" && connection is Connection<int> con1) _outputPort = con1;
+        if (portName == Input && connection is Connection<int> con0) _inputPort = con0;
+        if (portName == Output && connection is Connection<int> con1) _outputPort = con1;
         return this;
     }
 
     public IEnumerator Execute()
     {
-        if (_inputPort is null)
-            throw new InvalidOperationException("Input port is not set");
+        if (_inputPort is null) throw new InvalidOperationException("Input port is not set");
 
         while (true)
         {
-            if (_inputPort.IsClosed && !_inputPort.HasData)
-                break;
-
-            if (!_inputPort.HasData)
-            {
-                yield return null;
-                continue;
-            }
-
-            var packet = _inputPort.Receive();
-            _outputPort?.Send(packet * packet);
+            if (_inputPort.IsClosed && !_inputPort.HasData) break;
+            if (!_inputPort.HasData) { yield return null; continue; }
+            _outputPort?.Send(_inputPort.Receive() * _inputPort.Receive());
         }
 
         _outputPort?.Close();

--- a/Hypnode.System/Math/Squarer.cs
+++ b/Hypnode.System/Math/Squarer.cs
@@ -26,7 +26,8 @@ public class Squarer : INode
         {
             if (_inputPort.IsClosed && !_inputPort.HasData) break;
             if (!_inputPort.HasData) { yield return null; continue; }
-            _outputPort?.Send(_inputPort.Receive() * _inputPort.Receive());
+            var packet = _inputPort.Receive();
+            _outputPort?.Send(packet * packet);
         }
 
         _outputPort?.Close();

--- a/Hypnode.UnitTest/Logic/Compound/FullAdderByteTests.cs
+++ b/Hypnode.UnitTest/Logic/Compound/FullAdderByteTests.cs
@@ -1,9 +1,8 @@
 using Hypnode.Core;
 using Hypnode.Logic.Compound;
+using Hypnode.Logic.Gates;
 using Hypnode.Runtime;
 using Hypnode.System.Common;
-using Hypnode.Logic.Gates;
-using Hypnode.System.Math;
 
 namespace Hypnode.UnitTests.Logic.Compound;
 

--- a/Hypnode.UnitTest/Logic/Compound/FullAdderByteTests.cs
+++ b/Hypnode.UnitTest/Logic/Compound/FullAdderByteTests.cs
@@ -2,6 +2,8 @@ using Hypnode.Core;
 using Hypnode.Logic.Compound;
 using Hypnode.Runtime;
 using Hypnode.System.Common;
+using Hypnode.Logic.Gates;
+using Hypnode.System.Math;
 
 namespace Hypnode.UnitTests.Logic.Compound;
 
@@ -25,16 +27,16 @@ public abstract class FullAdderByteTests<TGraph> where TGraph : INodeGraph, new(
         var bin = graph.CreateConnection<byte>();
         var outsum = graph.CreateConnection<byte>();
 
-        graph.AddNode(new PulseValue<byte>(a)).SetPort("OUT", ain);
-        graph.AddNode(new PulseValue<byte>(b)).SetPort("OUT", bin);
+        graph.AddNode(new PulseValue<byte>(a)).SetPort(Ports.Output, ain);
+        graph.AddNode(new PulseValue<byte>(b)).SetPort(Ports.Output, bin);
 
         graph.AddNode(new FullAdderByte(new TGraph()))
-            .SetPort("INA", ain)
-            .SetPort("INB", bin)
-            .SetPort("OUTSUM", outsum);
+            .SetPort(AndGate.InputA, ain)
+            .SetPort(AndGate.InputB, bin)
+            .SetPort(FullAdder.OutputSum, outsum);
 
         var sumCell = new Register<byte>();
-        graph.AddNode(sumCell).SetPort("IN", outsum);
+        graph.AddNode(sumCell).SetPort(Ports.Input, outsum);
 
         graph.Evaluate();
 

--- a/Hypnode.UnitTest/Logic/Compound/FullAdderTests.cs
+++ b/Hypnode.UnitTest/Logic/Compound/FullAdderTests.cs
@@ -3,6 +3,8 @@ using Hypnode.Logic;
 using Hypnode.Logic.Compound;
 using Hypnode.Runtime;
 using Hypnode.System.Common;
+using Hypnode.Logic.Gates;
+using Hypnode.System.Math;
 
 namespace Hypnode.UnitTests.Logic.Compound;
 
@@ -25,22 +27,22 @@ public abstract class FullAdderTests<TGraph> where TGraph : INodeGraph, new()
         var outsum = graph.CreateConnection<LogicValue>();
         var outc = graph.CreateConnection<LogicValue>();
 
-        graph.AddNode(new PulseValue<LogicValue>(a)).SetPort("OUT", ain);
-        graph.AddNode(new PulseValue<LogicValue>(b)).SetPort("OUT", bin);
-        graph.AddNode(new PulseValue<LogicValue>(cIn)).SetPort("OUT", cin);
+        graph.AddNode(new PulseValue<LogicValue>(a)).SetPort(Ports.Output, ain);
+        graph.AddNode(new PulseValue<LogicValue>(b)).SetPort(Ports.Output, bin);
+        graph.AddNode(new PulseValue<LogicValue>(cIn)).SetPort(Ports.Output, cin);
 
         graph.AddNode(new FullAdder(new CoroutineNodeGraph()))
-            .SetPort("INA", ain)
-            .SetPort("INB", bin)
-            .SetPort("INC", cin)
-            .SetPort("OUTSUM", outsum)
-            .SetPort("OUTC", outc);
+            .SetPort(AndGate.InputA, ain)
+            .SetPort(AndGate.InputB, bin)
+            .SetPort(FullAdder.InputC, cin)
+            .SetPort(FullAdder.OutputSum, outsum)
+            .SetPort(FullAdder.OutputCarry, outc);
 
         var sumCell = new Register<LogicValue>();
-        graph.AddNode(sumCell).SetPort("IN", outsum);
+        graph.AddNode(sumCell).SetPort(Ports.Input, outsum);
 
         var carryCell = new Register<LogicValue>();
-        graph.AddNode(carryCell).SetPort("IN", outc);
+        graph.AddNode(carryCell).SetPort(Ports.Input, outc);
 
         graph.Evaluate();
 
@@ -69,16 +71,16 @@ public abstract class FullAdderTests<TGraph> where TGraph : INodeGraph, new()
         var bin = graph.CreateConnection<byte>();
         var outsum = graph.CreateConnection<byte>();
 
-        graph.AddNode(new PulseValue<byte>(a)).SetPort("OUT", ain);
-        graph.AddNode(new PulseValue<byte>(b)).SetPort("OUT", bin);
+        graph.AddNode(new PulseValue<byte>(a)).SetPort(Ports.Output, ain);
+        graph.AddNode(new PulseValue<byte>(b)).SetPort(Ports.Output, bin);
 
         graph.AddNode(new FullAdderByte(new TGraph()))
-            .SetPort("INA", ain)
-            .SetPort("INB", bin)
-            .SetPort("OUTSUM", outsum);
+            .SetPort(AndGate.InputA, ain)
+            .SetPort(AndGate.InputB, bin)
+            .SetPort(FullAdder.OutputSum, outsum);
 
         var sumCell = new Register<byte>();
-        graph.AddNode(sumCell).SetPort("IN", outsum);
+        graph.AddNode(sumCell).SetPort(Ports.Input, outsum);
 
         graph.Evaluate();
 

--- a/Hypnode.UnitTest/Logic/Compound/FullAdderTests.cs
+++ b/Hypnode.UnitTest/Logic/Compound/FullAdderTests.cs
@@ -1,10 +1,9 @@
 using Hypnode.Core;
 using Hypnode.Logic;
 using Hypnode.Logic.Compound;
+using Hypnode.Logic.Gates;
 using Hypnode.Runtime;
 using Hypnode.System.Common;
-using Hypnode.Logic.Gates;
-using Hypnode.System.Math;
 
 namespace Hypnode.UnitTests.Logic.Compound;
 

--- a/Hypnode.UnitTest/Logic/Gates/AndGateTests.cs
+++ b/Hypnode.UnitTest/Logic/Gates/AndGateTests.cs
@@ -3,7 +3,6 @@ using Hypnode.Logic;
 using Hypnode.Logic.Gates;
 using Hypnode.Runtime;
 using Hypnode.System.Common;
-using Hypnode.System.Math;
 
 namespace Hypnode.UnitTests.Logic.Gates;
 

--- a/Hypnode.UnitTest/Logic/Gates/AndGateTests.cs
+++ b/Hypnode.UnitTest/Logic/Gates/AndGateTests.cs
@@ -3,6 +3,7 @@ using Hypnode.Logic;
 using Hypnode.Logic.Gates;
 using Hypnode.Runtime;
 using Hypnode.System.Common;
+using Hypnode.System.Math;
 
 namespace Hypnode.UnitTests.Logic.Gates;
 
@@ -20,18 +21,18 @@ public abstract class AndGateTests<TGraph> where TGraph : INodeGraph, new()
         var connection3 = graph.CreateConnection<LogicValue>();
 
         graph.AddNode(new PulseValue<LogicValue>(a))
-            .SetPort("OUT", connection1);
+            .SetPort(Ports.Output, connection1);
 
         graph.AddNode(new PulseValue<LogicValue>(b))
-            .SetPort("OUT", connection2);
+            .SetPort(Ports.Output, connection2);
 
         graph.AddNode(new AndGate())
-            .SetPort("INA", connection1)
-            .SetPort("INB", connection2)
-            .SetPort("OUT", connection3);
+            .SetPort(AndGate.InputA, connection1)
+            .SetPort(AndGate.InputB, connection2)
+            .SetPort(Ports.Output, connection3);
 
         var result = new Register<LogicValue>();
-        graph.AddNode(result).SetPort("IN", connection3);
+        graph.AddNode(result).SetPort(Ports.Input, connection3);
 
         graph.Evaluate();
 

--- a/Hypnode.UnitTest/Logic/Gates/NotGateTests.cs
+++ b/Hypnode.UnitTest/Logic/Gates/NotGateTests.cs
@@ -3,7 +3,6 @@ using Hypnode.Logic;
 using Hypnode.Logic.Gates;
 using Hypnode.Runtime;
 using Hypnode.System.Common;
-using Hypnode.System.Math;
 
 namespace Hypnode.UnitTests.Logic.Gates;
 

--- a/Hypnode.UnitTest/Logic/Gates/NotGateTests.cs
+++ b/Hypnode.UnitTest/Logic/Gates/NotGateTests.cs
@@ -3,6 +3,7 @@ using Hypnode.Logic;
 using Hypnode.Logic.Gates;
 using Hypnode.Runtime;
 using Hypnode.System.Common;
+using Hypnode.System.Math;
 
 namespace Hypnode.UnitTests.Logic.Gates;
 
@@ -17,14 +18,14 @@ public abstract class NotGateTests<TGraph> where TGraph : INodeGraph, new()
         var connection2 = graph.CreateConnection<LogicValue>();
 
         graph.AddNode(new PulseValue<LogicValue>(value))
-            .SetPort("OUT", connection1);
+            .SetPort(Ports.Output, connection1);
 
         graph.AddNode(new NotGate())
-            .SetPort("IN", connection1)
-            .SetPort("OUT", connection2);
+            .SetPort(Ports.Input, connection1)
+            .SetPort(Ports.Output, connection2);
 
         var result = new Register<LogicValue>();
-        graph.AddNode(result).SetPort("IN", connection2);
+        graph.AddNode(result).SetPort(Ports.Input, connection2);
 
         graph.Evaluate();
 

--- a/Hypnode.UnitTest/Logic/Gates/OrGateTests.cs
+++ b/Hypnode.UnitTest/Logic/Gates/OrGateTests.cs
@@ -3,7 +3,6 @@ using Hypnode.Logic;
 using Hypnode.Logic.Gates;
 using Hypnode.Runtime;
 using Hypnode.System.Common;
-using Hypnode.System.Math;
 
 namespace Hypnode.UnitTests.Logic.Gates;
 

--- a/Hypnode.UnitTest/Logic/Gates/OrGateTests.cs
+++ b/Hypnode.UnitTest/Logic/Gates/OrGateTests.cs
@@ -3,6 +3,7 @@ using Hypnode.Logic;
 using Hypnode.Logic.Gates;
 using Hypnode.Runtime;
 using Hypnode.System.Common;
+using Hypnode.System.Math;
 
 namespace Hypnode.UnitTests.Logic.Gates;
 
@@ -20,18 +21,18 @@ public abstract class OrGateTests<TGraph> where TGraph : INodeGraph, new()
         var connection3 = graph.CreateConnection<LogicValue>();
 
         graph.AddNode(new PulseValue<LogicValue>(a))
-            .SetPort("OUT", connection1);
+            .SetPort(Ports.Output, connection1);
 
         graph.AddNode(new PulseValue<LogicValue>(b))
-            .SetPort("OUT", connection2);
+            .SetPort(Ports.Output, connection2);
 
         graph.AddNode(new OrGate())
-            .SetPort("INA", connection1)
-            .SetPort("INB", connection2)
-            .SetPort("OUT", connection3);
+            .SetPort(AndGate.InputA, connection1)
+            .SetPort(AndGate.InputB, connection2)
+            .SetPort(Ports.Output, connection3);
 
         var result = new Register<LogicValue>();
-        graph.AddNode(result).SetPort("IN", connection3);
+        graph.AddNode(result).SetPort(Ports.Input, connection3);
 
         graph.Evaluate();
 

--- a/Hypnode.UnitTest/Logic/Gates/XorGateTests.cs
+++ b/Hypnode.UnitTest/Logic/Gates/XorGateTests.cs
@@ -3,7 +3,6 @@ using Hypnode.Logic;
 using Hypnode.Logic.Gates;
 using Hypnode.Runtime;
 using Hypnode.System.Common;
-using Hypnode.System.Math;
 
 namespace Hypnode.UnitTests.Logic.Gates;
 

--- a/Hypnode.UnitTest/Logic/Gates/XorGateTests.cs
+++ b/Hypnode.UnitTest/Logic/Gates/XorGateTests.cs
@@ -3,6 +3,7 @@ using Hypnode.Logic;
 using Hypnode.Logic.Gates;
 using Hypnode.Runtime;
 using Hypnode.System.Common;
+using Hypnode.System.Math;
 
 namespace Hypnode.UnitTests.Logic.Gates;
 
@@ -20,18 +21,18 @@ public abstract class XorGateTests<TGraph> where TGraph : INodeGraph, new()
         var connection3 = graph.CreateConnection<LogicValue>();
 
         graph.AddNode(new PulseValue<LogicValue>(a))
-            .SetPort("OUT", connection1);
+            .SetPort(Ports.Output, connection1);
 
         graph.AddNode(new PulseValue<LogicValue>(b))
-            .SetPort("OUT", connection2);
+            .SetPort(Ports.Output, connection2);
 
         graph.AddNode(new XorGate())
-            .SetPort("INA", connection1)
-            .SetPort("INB", connection2)
-            .SetPort("OUT", connection3);
+            .SetPort(AndGate.InputA, connection1)
+            .SetPort(AndGate.InputB, connection2)
+            .SetPort(Ports.Output, connection3);
 
         var result = new Register<LogicValue>();
-        graph.AddNode(result).SetPort("IN", connection3);
+        graph.AddNode(result).SetPort(Ports.Input, connection3);
 
         graph.Evaluate();
 

--- a/Hypnode.UnitTest/Logic/Utils/ByteSplitterInTests.cs
+++ b/Hypnode.UnitTest/Logic/Utils/ByteSplitterInTests.cs
@@ -3,6 +3,7 @@ using Hypnode.Logic;
 using Hypnode.Logic.Utils;
 using Hypnode.Runtime;
 using Hypnode.System.Common;
+using Hypnode.System.Math;
 
 namespace Hypnode.UnitTests.Logic.Utils;
 
@@ -27,10 +28,10 @@ public abstract class ByteSplitterInTests<TGraph> where TGraph : INodeGraph, new
         var b6c = graph.CreateConnection<LogicValue>();
         var b7c = graph.CreateConnection<LogicValue>();
 
-        graph.AddNode(new PulseValue<byte>(value)).SetPort("OUT", input);
+        graph.AddNode(new PulseValue<byte>(value)).SetPort(Ports.Output, input);
 
         graph.AddNode(new ByteSplitterIn())
-            .SetPort("IN", input)
+            .SetPort(Ports.Input, input)
             .SetPort(0.ToString(), b0c)
             .SetPort(1.ToString(), b1c)
             .SetPort(2.ToString(), b2c)
@@ -40,14 +41,14 @@ public abstract class ByteSplitterInTests<TGraph> where TGraph : INodeGraph, new
             .SetPort(6.ToString(), b6c)
             .SetPort(7.ToString(), b7c);
 
-        var b0 = new Register<LogicValue>(); graph.AddNode(b0).SetPort("IN", b0c);
-        var b1 = new Register<LogicValue>(); graph.AddNode(b1).SetPort("IN", b1c);
-        var b2 = new Register<LogicValue>(); graph.AddNode(b2).SetPort("IN", b2c);
-        var b3 = new Register<LogicValue>(); graph.AddNode(b3).SetPort("IN", b3c);
-        var b4 = new Register<LogicValue>(); graph.AddNode(b4).SetPort("IN", b4c);
-        var b5 = new Register<LogicValue>(); graph.AddNode(b5).SetPort("IN", b5c);
-        var b6 = new Register<LogicValue>(); graph.AddNode(b6).SetPort("IN", b6c);
-        var b7 = new Register<LogicValue>(); graph.AddNode(b7).SetPort("IN", b7c);
+        var b0 = new Register<LogicValue>(); graph.AddNode(b0).SetPort(Ports.Input, b0c);
+        var b1 = new Register<LogicValue>(); graph.AddNode(b1).SetPort(Ports.Input, b1c);
+        var b2 = new Register<LogicValue>(); graph.AddNode(b2).SetPort(Ports.Input, b2c);
+        var b3 = new Register<LogicValue>(); graph.AddNode(b3).SetPort(Ports.Input, b3c);
+        var b4 = new Register<LogicValue>(); graph.AddNode(b4).SetPort(Ports.Input, b4c);
+        var b5 = new Register<LogicValue>(); graph.AddNode(b5).SetPort(Ports.Input, b5c);
+        var b6 = new Register<LogicValue>(); graph.AddNode(b6).SetPort(Ports.Input, b6c);
+        var b7 = new Register<LogicValue>(); graph.AddNode(b7).SetPort(Ports.Input, b7c);
 
         graph.Evaluate();
 

--- a/Hypnode.UnitTest/Logic/Utils/ByteSplitterInTests.cs
+++ b/Hypnode.UnitTest/Logic/Utils/ByteSplitterInTests.cs
@@ -3,7 +3,6 @@ using Hypnode.Logic;
 using Hypnode.Logic.Utils;
 using Hypnode.Runtime;
 using Hypnode.System.Common;
-using Hypnode.System.Math;
 
 namespace Hypnode.UnitTests.Logic.Utils;
 

--- a/Hypnode.UnitTest/Logic/Utils/ByteSplitterOutTests.cs
+++ b/Hypnode.UnitTest/Logic/Utils/ByteSplitterOutTests.cs
@@ -3,6 +3,7 @@ using Hypnode.Logic;
 using Hypnode.Logic.Utils;
 using Hypnode.Runtime;
 using Hypnode.System.Common;
+using Hypnode.System.Math;
 
 namespace Hypnode.UnitTests.Logic.Utils;
 
@@ -28,17 +29,17 @@ public abstract class ByteSplitterOutTests<TGraph> where TGraph : INodeGraph, ne
 
         var splitter = graph.AddNode(new ByteSplitterOut());
 
-        graph.AddConnection<LogicValue>(b0n, "OUT", splitter, "0");
-        graph.AddConnection<LogicValue>(b1n, "OUT", splitter, "1");
-        graph.AddConnection<LogicValue>(b2n, "OUT", splitter, "2");
-        graph.AddConnection<LogicValue>(b3n, "OUT", splitter, "3");
-        graph.AddConnection<LogicValue>(b4n, "OUT", splitter, "4");
-        graph.AddConnection<LogicValue>(b5n, "OUT", splitter, "5");
-        graph.AddConnection<LogicValue>(b6n, "OUT", splitter, "6");
-        graph.AddConnection<LogicValue>(b7n, "OUT", splitter, "7");
+        graph.AddConnection<LogicValue>(b0n, Ports.Output, splitter, "0");
+        graph.AddConnection<LogicValue>(b1n, Ports.Output, splitter, "1");
+        graph.AddConnection<LogicValue>(b2n, Ports.Output, splitter, "2");
+        graph.AddConnection<LogicValue>(b3n, Ports.Output, splitter, "3");
+        graph.AddConnection<LogicValue>(b4n, Ports.Output, splitter, "4");
+        graph.AddConnection<LogicValue>(b5n, Ports.Output, splitter, "5");
+        graph.AddConnection<LogicValue>(b6n, Ports.Output, splitter, "6");
+        graph.AddConnection<LogicValue>(b7n, Ports.Output, splitter, "7");
 
         var result = graph.AddNode(new Register<byte>());
-        graph.AddConnection<byte>(splitter, "OUT", result, "IN");
+        graph.AddConnection<byte>(splitter, Ports.Output, result, Ports.Input);
 
         graph.Evaluate();
 

--- a/Hypnode.UnitTest/Logic/Utils/ByteSplitterOutTests.cs
+++ b/Hypnode.UnitTest/Logic/Utils/ByteSplitterOutTests.cs
@@ -3,7 +3,6 @@ using Hypnode.Logic;
 using Hypnode.Logic.Utils;
 using Hypnode.Runtime;
 using Hypnode.System.Common;
-using Hypnode.System.Math;
 
 namespace Hypnode.UnitTests.Logic.Utils;
 

--- a/Hypnode.UnitTest/System/Common/MultiPulseTests.cs
+++ b/Hypnode.UnitTest/System/Common/MultiPulseTests.cs
@@ -3,7 +3,6 @@ using Hypnode.Logic;
 using Hypnode.Runtime;
 using Hypnode.System.Common;
 using Moq;
-using Hypnode.System.Math;
 
 namespace Hypnode.UnitTests.System.Common;
 

--- a/Hypnode.UnitTest/System/Common/MultiPulseTests.cs
+++ b/Hypnode.UnitTest/System/Common/MultiPulseTests.cs
@@ -3,6 +3,7 @@ using Hypnode.Logic;
 using Hypnode.Runtime;
 using Hypnode.System.Common;
 using Moq;
+using Hypnode.System.Math;
 
 namespace Hypnode.UnitTests.System.Common;
 
@@ -17,7 +18,7 @@ public abstract class MultiPulseTests<TGraph> where TGraph : INodeGraph, new()
         var multiPulse = graph.AddNode(new MultiPulseValue<LogicValue>([value]));
         var result = graph.AddNode(new Register<LogicValue>());
 
-        graph.AddConnection<LogicValue>(multiPulse, "OUT", result, "IN");
+        graph.AddConnection<LogicValue>(multiPulse, Ports.Output, result, Ports.Input);
 
         graph.Evaluate();
 
@@ -35,7 +36,7 @@ public abstract class MultiPulseTests<TGraph> where TGraph : INodeGraph, new()
         var connection = new Mock<Connection<int>>();
         var multiPulse = graph.AddNode(new MultiPulseValue<int>([value]));
 
-        multiPulse.SetPort("OUT", connection.Object);
+        multiPulse.SetPort(Ports.Output, connection.Object);
 
         graph.Evaluate();
 

--- a/Hypnode.UnitTest/System/Common/PulseTests.cs
+++ b/Hypnode.UnitTest/System/Common/PulseTests.cs
@@ -3,7 +3,6 @@ using Hypnode.Logic;
 using Hypnode.Runtime;
 using Hypnode.System.Common;
 using Moq;
-using Hypnode.System.Math;
 
 namespace Hypnode.UnitTests.System.Common;
 

--- a/Hypnode.UnitTest/System/Common/PulseTests.cs
+++ b/Hypnode.UnitTest/System/Common/PulseTests.cs
@@ -3,6 +3,7 @@ using Hypnode.Logic;
 using Hypnode.Runtime;
 using Hypnode.System.Common;
 using Moq;
+using Hypnode.System.Math;
 
 namespace Hypnode.UnitTests.System.Common;
 
@@ -17,7 +18,7 @@ public abstract class PulseTests<TGraph> where TGraph : INodeGraph, new()
         var pulse = graph.AddNode(new PulseValue<LogicValue>(value));
         var result = graph.AddNode(new Register<LogicValue>());
 
-        graph.AddConnection<LogicValue>(pulse, "OUT", result, "IN");
+        graph.AddConnection<LogicValue>(pulse, Ports.Output, result, Ports.Input);
 
         graph.Evaluate();
 
@@ -35,7 +36,7 @@ public abstract class PulseTests<TGraph> where TGraph : INodeGraph, new()
         var connection = new Mock<Connection<int>>();
         var pulse = graph.AddNode(new PulseValue<int>(value));
 
-        pulse.SetPort("OUT", connection.Object);
+        pulse.SetPort(Ports.Output, connection.Object);
 
         graph.Evaluate();
 

--- a/Hypnode.UnitTest/System/Common/VoidTests.cs
+++ b/Hypnode.UnitTest/System/Common/VoidTests.cs
@@ -1,8 +1,8 @@
 using Hypnode.Core;
+using Hypnode.Logic;
 using Hypnode.Runtime;
 using Hypnode.System.Common;
 using Moq;
-using Hypnode.System.Math;
 
 namespace Hypnode.UnitTests.System.Common;
 

--- a/Hypnode.UnitTest/System/Common/VoidTests.cs
+++ b/Hypnode.UnitTest/System/Common/VoidTests.cs
@@ -2,6 +2,7 @@ using Hypnode.Core;
 using Hypnode.Runtime;
 using Hypnode.System.Common;
 using Moq;
+using Hypnode.System.Math;
 
 namespace Hypnode.UnitTests.System.Common;
 
@@ -13,8 +14,8 @@ public abstract class VoidTests<TGraph> where TGraph : INodeGraph, new()
         var graph = new TGraph();
         var connection = graph.CreateConnection<byte>();
 
-        graph.AddNode(new PulseValue<byte>(1)).SetPort("OUT", connection);
-        graph.AddNode(new VoidSink<byte>()).SetPort("_", connection);
+        graph.AddNode(new PulseValue<byte>(1)).SetPort(Ports.Output, connection);
+        graph.AddNode(new VoidSink<byte>()).SetPort(VoidSink<LogicValue>.Input, connection);
 
         graph.Evaluate();
 
@@ -30,7 +31,7 @@ public abstract class VoidTests<TGraph> where TGraph : INodeGraph, new()
         connection.Setup(c => c.TryReceive(out It.Ref<int>.IsAny)).Returns(false);
 
         var sink = graph.AddNode(new VoidSink<int>());
-        sink.SetPort("_", connection.Object);
+        sink.SetPort(VoidSink<LogicValue>.Input, connection.Object);
 
         graph.Evaluate();
 
@@ -54,7 +55,7 @@ public abstract class VoidTests<TGraph> where TGraph : INodeGraph, new()
             connections.Add(connection);
             connection.Setup(c => c.TryReceive(out It.Ref<int>.IsAny)).Returns(false);
 
-            sink.SetPort("_", connection.Object);
+            sink.SetPort(VoidSink<LogicValue>.Input, connection.Object);
         }
 
         graph.Evaluate();
@@ -70,12 +71,12 @@ public abstract class VoidTests<TGraph> where TGraph : INodeGraph, new()
         var connection1 = graph.CreateConnection<byte>();
         var connection2 = graph.CreateConnection<byte>();
 
-        graph.AddNode(new PulseValue<byte>(1)).SetPort("OUT", connection1);
-        graph.AddNode(new PulseValue<byte>(1)).SetPort("OUT", connection2);
+        graph.AddNode(new PulseValue<byte>(1)).SetPort(Ports.Output, connection1);
+        graph.AddNode(new PulseValue<byte>(1)).SetPort(Ports.Output, connection2);
 
         graph.AddNode(new VoidSink<byte>())
-            .SetPort("_", connection1)
-            .SetPort("_", connection2);
+            .SetPort(VoidSink<LogicValue>.Input, connection1)
+            .SetPort(VoidSink<LogicValue>.Input, connection2);
 
         graph.Evaluate();
 

--- a/Hypnode.UnitTest/System/Math/SquarerTests.cs
+++ b/Hypnode.UnitTest/System/Math/SquarerTests.cs
@@ -23,8 +23,8 @@ public abstract class SquarerTests<TGraph> where TGraph : INodeGraph, new()
         var squarer = graph.AddNode(new Squarer());
         var result = graph.AddNode(new Register<int>());
 
-        graph.AddConnection<int>(pulse, "OUT", squarer, "IN");
-        graph.AddConnection<int>(squarer, "OUT", result, "IN");
+        graph.AddConnection<int>(pulse, Ports.Output, squarer, Ports.Input);
+        graph.AddConnection<int>(squarer, Ports.Output, result, Ports.Input);
 
         graph.Evaluate();
 


### PR DESCRIPTION
  Add Ports.Input and Ports.Output to Hypnode.Core for the common "IN"/"OUT"
  port names shared across all generic nodes. Add node-specific constants
  (InputA, InputB, InputC, OutputSum, OutputCarry, etc.) directly on each node
  class. Update every SetPort call site — node internals, compound nodes, and
  all tests — to use these constants instead of raw string literals. Also
  collapse the ByteSplitterIn/Out SetPort implementations from eight individual
  if-statements to a single int.TryParse loop.